### PR TITLE
CMenuManager does not have a m_nCurrentMenuScreen member fix

### DIFF
--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -40,7 +40,7 @@ public:
             if (!MenuNew || !MenuNew->menuManager)
                 return;
 
-            switch (MenuNew->menuManager->m_nCurrentMenuScreen) {
+            switch (MenuNew->menuManager->m_nCurrentMenuPage) {
             case MENUPAGE_MAP:
                 MenuNew->MapInput();
                 MenuNew->DrawMap();


### PR DESCRIPTION
Closes #1 

Changing the variable name to one that does exist and corresponds to the correct functionality in the CMenuManager fixes the issue. Has been tested in-game by me.